### PR TITLE
Corrige erro

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'to_do_list',
 ]
 


### PR DESCRIPTION
# BUGFIXES :bug:

* Correção do erro "**ModuleNotFoundError: No module named 'rest_framework'**". Para tal, foi adicionado o app "rest_framework" nas configurações do projeto
`INSTALLED_APPS = [
    ...,
    'rest_framework',
    ...,
]`